### PR TITLE
Mention GitHub repo URL in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Ease the transition between R vectors and markdown
     the unambiguous CommonMark specification by John MacFarlane (2019)
     <https://spec.commonmark.org/>.
 License: GPL-3
-URL: https://kiernann.com/gluedown/
+URL: https://kiernann.com/gluedown/, https://github.com/kiernann/gluedown/
 BugReports: https://github.com/kiernann/gluedown/issues
 Depends: 
     R (>= 3.3)


### PR DESCRIPTION
Hi @kiernann :wave: 
Great package!
A very simple edit to the description file which will link automatically the GitHub repo in the `pkgdown` website.