### PR TITLE
Tweak tests for markdown v1.3

### DIFF
--- a/R/md-convert.R
+++ b/R/md-convert.R
@@ -24,7 +24,7 @@ md_convert <- function(x, frag = TRUE, disallow = TRUE) {
     stop("Package 'markdown' needed for this function to work.")
   } else {
     html <- markdown::mark_html(text = x, options = c(
-      if (frag) "-standalone", "-smart"
+      if (frag) "-standalone", "-smart", "-tasklist"
     ))
     if (disallow) {
       md_disallow(html)

--- a/R/md-convert.R
+++ b/R/md-convert.R
@@ -23,7 +23,9 @@ md_convert <- function(x, frag = TRUE, disallow = TRUE) {
   if (!has_markdown()) {
     stop("Package 'markdown' needed for this function to work.")
   } else {
-    html <- markdown::markdownToHTML(text = x, fragment.only = frag)
+    html <- markdown::mark_html(text = x, options = c(
+      if (frag) "-standalone", "-smart"
+    ))
     if (disallow) {
       md_disallow(html)
     } else {

--- a/tests/testthat/test-4.5-fenced-code.R
+++ b/tests/testthat/test-4.5-fenced-code.R
@@ -80,7 +80,7 @@ test_that("md_fence uses an info string that creates a class tag (ex. 112)", {
   node <- md_convert(lines) %>%
     find_nodes("code") %>%
     html_attr("class")
-  expect_equal(node, "ruby")
+  expect_match(node, "^(language-)?ruby$")
 })
 
 test_that("md_fence info string can ignore extra (ex. 113)", {

--- a/tests/testthat/test-generic-functions.R
+++ b/tests/testthat/test-generic-functions.R
@@ -21,7 +21,7 @@ test_that("md_list can create all list types", {
     html_node("ul") %>%
     html_nodes("li") %>%
     html_text() %>%
-    str_remove("\\[(.*)\\]\\s") %>%
+    str_remove("(\\[.*\\])?\\s") %>%
     expect_equal(x)
   x %>%
     md_list(type = "order") %>%

--- a/tests/testthat/test-generic-functions.R
+++ b/tests/testthat/test-generic-functions.R
@@ -21,7 +21,7 @@ test_that("md_list can create all list types", {
     html_node("ul") %>%
     html_nodes("li") %>%
     html_text() %>%
-    str_remove("(\\[.*\\])?\\s") %>%
+    str_remove("\\[(.*)\\]\\s") %>%
     expect_equal(x)
   x %>%
     md_list(type = "order") %>%


### PR DESCRIPTION
1. The `tasklist` extension is enabled by default in **markdown** now,  so there will be spaces before the task items, which will break this test: https://github.com/kiernann/gluedown/blob/cc2b149c2ae06eb9a2c7a5c8251cf4f13ff00c5a/tests/testthat/test-generic-functions.R#L17-L25
2. Language class names have a `language-` prefix now.
3. The `smart` extension is also enabled, which will convert straight quotes to curly quotes and break this test: https://github.com/kiernann/gluedown/blob/cc2b149c2ae06eb9a2c7a5c8251cf4f13ff00c5a/tests/testthat/test-6.14-textual-content.R#L12

I've disabled the `tasklist` and `smart` options in this PR.