### PR TITLE
Use `mark_html(template = FALSE)` instead of `options = "-standalone"`

### DIFF
--- a/R/md-convert.R
+++ b/R/md-convert.R
@@ -23,8 +23,8 @@ md_convert <- function(x, frag = TRUE, disallow = TRUE) {
   if (!has_markdown()) {
     stop("Package 'markdown' needed for this function to work.")
   } else {
-    html <- markdown::mark_html(text = x, options = c(
-      if (frag) "-standalone", "-smart", "-tasklist"
+    html <- markdown::mark_html(text = x, template = !frag, options = c(
+      "-smart", "-tasklist"
     ))
     if (disallow) {
       md_disallow(html)


### PR DESCRIPTION
The option `standalone` will be deprecated and removed in the future.

It will be nice if you can make a new CRAN release at some point. There is no hurry, though. Thank you very much!