### PR TITLE
Cleanup: dead code, stale deps, deprecated rvest API, CI versions

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,8 +21,6 @@ Imports:
     magrittr (>= 2.0.1)
 Suggests: 
     covr (>= 3.3.2),
-    dplyr (>= 0.8.3),
-    httr (>= 1.4.1),
     knitr (>= 1.25),
     markdown (>= 1.1),
     mockr (>= 0.1),

--- a/R/md-table.R
+++ b/R/md-table.R
@@ -43,7 +43,6 @@ md_table <- function(x, ...) {
       x <- apply(x, 2, function(z) sprintf(glue::glue("%-{max(nchar(z))}s"), z))
     }
     s <- strrep("-", apply(x, 2, function(z) max(nchar(z))))
-    num_cols <- vapply(x, is.numeric, logical(1))
     s <- gsub("^-", ":", s)
     if (nrow(x) >= 2) {
       x <- rbind(x[1, ], unname(s), x[2:nrow(x), ])

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,7 +27,7 @@ has_markdown <- function() {
 }
 
 find_nodes <- function(md, node) {
-  rvest::html_nodes(xml2::read_html(md_convert(md)), node)
+  rvest::html_elements(xml2::read_html(md_convert(md)), node)
 }
 
 expect_empty <- function(object) {

--- a/tests/testthat/test-5.1-block-quotes.R
+++ b/tests/testthat/test-5.1-block-quotes.R
@@ -25,7 +25,7 @@ test_that("md_quote can create an empty block quote (ex. 217)", {
   node <- md_quote("") %>%
     md_convert() %>%
     read_html() %>%
-    html_nodes("blockquote") %>%
+    html_elements("blockquote") %>%
     html_text(trim = TRUE)
   expect_nchar(node, 0)
 })
@@ -50,7 +50,7 @@ test_that("md_quotes with blank lines create paragraphs (ex. 222)", {
     md_convert() %>%
     read_html() %>%
     html_node("blockquote") %>%
-    html_nodes("p") %>%
+    html_elements("p") %>%
     html_text(trim = TRUE)
   expect_equal(node, text[which(text != "")])
 })
@@ -61,6 +61,6 @@ test_that("md_quote can create nested block qutoes (ex. 228)", {
   nodes <- lines %>%
     md_convert() %>%
     read_html() %>%
-    html_nodes("blockquote")
+    html_elements("blockquote")
   expect_length(nodes, 3)
 })

--- a/tests/testthat/test-5.3-task-list.R
+++ b/tests/testthat/test-5.3-task-list.R
@@ -12,7 +12,7 @@ test_that("md_task creates an <ul> list with checks (ex. 279)", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text()
   list %>%
     str_remove("\\[.*\\]\\s") %>%
@@ -29,7 +29,7 @@ test_that("md_task creates an <ul> list without checks", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     str_remove("\\[.*\\]\\s") %>%
     expect_equal(text)

--- a/tests/testthat/test-5.4-lists.R
+++ b/tests/testthat/test-5.4-lists.R
@@ -12,7 +12,7 @@ test_that("md_bullet creates an <ul> tag with vector text (ex. 281)", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })
@@ -25,7 +25,7 @@ test_that("md_order creates an <ol> tag with vector text (ex. 282)", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })
@@ -37,7 +37,7 @@ test_that("md_order works without sequence", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })
@@ -49,7 +49,7 @@ test_that("md_order can pad when markers differ in length", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })

--- a/tests/testthat/test-generic-functions.R
+++ b/tests/testthat/test-generic-functions.R
@@ -11,7 +11,7 @@ test_that("md_list can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(x)
   x %>%
@@ -19,7 +19,7 @@ test_that("md_list can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     str_remove("\\[(.*)\\]\\s") %>%
     expect_equal(x)
@@ -28,7 +28,7 @@ test_that("md_list can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(x)
 })
@@ -41,7 +41,7 @@ test_that("md_chunk can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("pre") %>%
-    html_nodes("code") %>%
+    html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
   x %>%
@@ -49,7 +49,7 @@ test_that("md_chunk can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("pre") %>%
-    html_nodes("code") %>%
+    html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
   x %>%
@@ -57,7 +57,7 @@ test_that("md_chunk can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("pre") %>%
-    html_nodes("code") %>%
+    html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
 })


### PR DESCRIPTION
Closes #35, #36, #37, #39.

## Changes

**`R/md-table.R`** — Remove `num_cols <- vapply(x, is.numeric, logical(1))`. The variable was computed but never read; iterating a matrix with `vapply()` would have yielded element-wise results anyway, not column-wise.

**`DESCRIPTION`** — Remove `dplyr` and `httr` from `Suggests`. Both were explicitly dropped in v1.0.1 per NEWS.md but never removed from the file. Neither appears in source or test code.

**`R/utils.R` + 4 test files** — Replace `rvest::html_nodes()` with `html_elements()` everywhere. `html_nodes()` was deprecated in rvest 1.0.0. Drop-in replacement, no behavior change. Affected test files: `test-5.1-block-quotes.R`, `test-5.3-task-list.R`, `test-5.4-lists.R`, `test-generic-functions.R`.

**`.github/workflows/`** — Bump `actions/checkout@v3` → `@v4` in all three workflow files (`check-standard.yaml`, `pkgdown.yaml`, `test-coverage.yaml`).

## Tests

128 passing, 9 skipped (same pre-existing skips as before).