### PR TITLE
Modernize to testthat 3 edition and complete rvest API migration

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,11 +28,12 @@ Suggests:
     rvest (>= 0.3.2),
     spelling (>= 2.1),
     stringr (>= 1.4.0),
-    testthat (>= 2.1.0),
+    testthat (>= 3.0.0),
     xml2 (>= 1.3.2)
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
 Language: en-US
+Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,8 +21,6 @@ Imports:
     magrittr (>= 2.0.1)
 Suggests: 
     covr (>= 3.3.2),
-    dplyr (>= 0.8.3),
-    httr (>= 1.4.1),
     knitr (>= 1.25),
     markdown (>= 1.1),
     mockr (>= 0.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Suggests:
     covr (>= 3.3.2),
     knitr (>= 1.25),
     markdown (>= 1.1),
-    mockr (>= 0.1),
     rmarkdown (>= 1.16),
     rvest (>= 0.3.2),
     spelling (>= 2.1),

--- a/R/md-table.R
+++ b/R/md-table.R
@@ -43,7 +43,6 @@ md_table <- function(x, ...) {
       x <- apply(x, 2, function(z) sprintf(glue::glue("%-{max(nchar(z))}s"), z))
     }
     s <- strrep("-", apply(x, 2, function(z) max(nchar(z))))
-    num_cols <- vapply(x, is.numeric, logical(1))
     s <- gsub("^-", ":", s)
     if (nrow(x) >= 2) {
       x <- rbind(x[1, ], unname(s), x[2:nrow(x), ])

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,7 +27,7 @@ has_markdown <- function() {
 }
 
 find_nodes <- function(md, node) {
-  rvest::html_nodes(xml2::read_html(md_convert(md)), node)
+  rvest::html_elements(xml2::read_html(md_convert(md)), node)
 }
 
 expect_empty <- function(object) {

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://k5cents.github.io/gluedown/
+
+template:
+  bootstrap: 5

--- a/tests/testthat/helper-packages.R
+++ b/tests/testthat/helper-packages.R
@@ -1,0 +1,3 @@
+library(rvest)
+library(glue)
+library(stringr)

--- a/tests/testthat/test-4.1-thematic-breaks.R
+++ b/tests/testthat/test-4.1-thematic-breaks.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(glue)
-library(rvest)
 
 test_that("md_rule creates <hr> tags (ex. 13)", {
   # https://github.github.com/gfm/#example-13
@@ -77,7 +73,7 @@ test_that("md_rule can creat a <h2> withing a hypeh bullet list (ex. 31)", {
   lines <- c("Foo", md_rule(space = TRUE)) %>% md_bullet("-")
   node <- md_convert(lines) %>%
     find_nodes("li") %>%
-    html_node("hr")
+    html_element("hr")
   expect_false(is.na(node[2]))
 })
 

--- a/tests/testthat/test-4.10-tables.R
+++ b/tests/testthat/test-4.10-tables.R
@@ -32,17 +32,13 @@ test_that("md_table can create a table with no body (ex. 205)", {
 })
 
 test_that("md_table works without knitr", {
-  skip_if_not_installed("mockr")
+  local_mocked_bindings(has_knitr = function() FALSE)
   df <- data.frame(
     foo = "baz",
     bar = "bim",
     stringsAsFactors = FALSE
   )
-  md <- mockr::with_mock(
-    .env = as.environment("package:gluedown"),
-    `has_knitr` = function() FALSE,
-    md_table(df)
-  )
+  md <- md_table(df)
   node <- md %>%
     md_convert() %>%
     read_html() %>%
@@ -53,17 +49,13 @@ test_that("md_table works without knitr", {
 })
 
 test_that("md_table works without knitr and no body", {
-  skip_if_not_installed("mockr")
+  local_mocked_bindings(has_knitr = function() FALSE)
   df <- data.frame(
     foo = logical(),
     bar = logical(),
     stringsAsFactors = FALSE
   )
-  md <- mockr::with_mock(
-    .env = as.environment("package:gluedown"),
-    `has_knitr` = function() FALSE,
-    md_table(df)
-  )
+  md <- md_table(df)
   node <- md %>%
     md_convert() %>%
     read_html() %>%

--- a/tests/testthat/test-4.10-tables.R
+++ b/tests/testthat/test-4.10-tables.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_table creates a single <table> tag (ex. 198)", {
   # https://github.github.com/gfm/#example-198
@@ -14,7 +9,7 @@ test_that("md_table creates a single <table> tag (ex. 198)", {
   node <- md_table(df) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("table") %>%
+    html_element("table") %>%
     html_table() %>%
     as.data.frame()
   expect_equal(node, df)
@@ -30,7 +25,7 @@ test_that("md_table can create a table with no body (ex. 205)", {
   node <- md_table(df) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("table") %>%
+    html_element("table") %>%
     html_table() %>%
     as.data.frame()
   expect_equal(node, df)
@@ -51,7 +46,7 @@ test_that("md_table works without knitr", {
   node <- md %>%
     md_convert() %>%
     read_html() %>%
-    html_node("table") %>%
+    html_element("table") %>%
     html_table() %>%
     as.data.frame()
   expect_equal(node, df)
@@ -72,7 +67,7 @@ test_that("md_table works without knitr and no body", {
   node <- md %>%
     md_convert() %>%
     read_html() %>%
-    html_node("table") %>%
+    html_element("table") %>%
     html_table() %>%
     as.data.frame()
   expect_equal(node, df)

--- a/tests/testthat/test-4.2-atx-headings.R
+++ b/tests/testthat/test-4.2-atx-headings.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(glue)
-library(rvest)
 
 test_that("md_heading creates tags <h2> through <h6> (ex. 32)", {
   # https://github.github.com/gfm/#example-32

--- a/tests/testthat/test-4.3-setext-headings.R
+++ b/tests/testthat/test-4.3-setext-headings.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(glue)
-library(rvest)
 
 test_that("md_setext errors at levels greater than 2", {
   expect_error(md_setext("Foo", 3))

--- a/tests/testthat/test-4.4-indented-code.R
+++ b/tests/testthat/test-4.4-indented-code.R
@@ -29,7 +29,6 @@ test_that("md_inline creates lines without other formatting (ex. 80)", {
 })
 
 test_that("md_indent doesn't interupt a paragraph (ex. 83)", {
-  skip("could not find function 'condition'")
   # https://github.github.com/gfm/#example-83
   node <- c("Foo", md_indent("bar")) %>%
     md_softline() %>%

--- a/tests/testthat/test-4.4-indented-code.R
+++ b/tests/testthat/test-4.4-indented-code.R
@@ -1,15 +1,10 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(glue)
-library(rvest)
 
 test_that("md_indent creates a simple code block (ex. 77)", {
   # https://github.github.com/gfm/#example-77
   lines <- md_indent(c("a simple", "  indented code block"))
   node <- md_convert(lines) %>%
     find_nodes("pre") %>%
-    html_node("code") %>%
+    html_element("code") %>%
     html_text() %>%
     str_trim() %>%
     str_squish()
@@ -33,18 +28,18 @@ test_that("md_inline creates lines without other formatting (ex. 80)", {
   expect_empty(node)
 })
 
-expect_that("md_indent doesn't interupt a paragraph (ex. 83)", {
+test_that("md_indent doesn't interupt a paragraph (ex. 83)", {
   skip("could not find function 'condition'")
   # https://github.github.com/gfm/#example-83
   node <- c("Foo", md_indent("bar")) %>%
     md_softline() %>%
     md_convert() %>%
     read_html() %>%
-    html_node("code")
+    html_element("code")
   expect_true(is.na(node))
 })
 
-expect_that("md_indent ends after non-blank line (ex. 84)", {
+test_that("md_indent ends after non-blank line (ex. 84)", {
   # https://github.github.com/gfm/#example-84
   node <- c(md_indent("Foo"), "bar") %>%
     md_softline() %>%

--- a/tests/testthat/test-4.5-fenced-code.R
+++ b/tests/testthat/test-4.5-fenced-code.R
@@ -1,15 +1,10 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(glue)
-library(rvest)
 
 test_that("md_fence creates a simple backtick code block (ex. 89)", {
   # https://github.github.com/gfm/#example-89
   lines <- md_fence(c("<", " >"), info = NULL)
   node <- md_convert(lines) %>%
     find_nodes("pre") %>%
-    html_node("code")
+    html_element("code")
   expect_full(node)
 })
 
@@ -18,7 +13,7 @@ test_that("md_fence creates a simple tilde code block (ex. 90)", {
   lines <- md_fence(c("<", " >"), char = "`", info = NULL)
   node <- md_convert(lines) %>%
     find_nodes("pre") %>%
-    html_node("code")
+    html_element("code")
   expect_full(node)
 })
 

--- a/tests/testthat/test-4.7-link-references.R
+++ b/tests/testthat/test-4.7-link-references.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(glue)
-library(rvest)
 
 test_that("md_reference creates a simple <href> tag (ex. 161)", {
   # https://github.github.com/gfm/#example-161

--- a/tests/testthat/test-4.8-paragraphs.R
+++ b/tests/testthat/test-4.8-paragraphs.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(glue)
-library(rvest)
 
 test_that("md_paragraph creates two simple paragraphs (ex. 189)", {
   # https://github.github.com/gfm/#example-189

--- a/tests/testthat/test-4.9-blank-lines.R
+++ b/tests/testthat/test-4.9-blank-lines.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_blank creates lines that are ignored (ex. 197)", {
   # https://github.github.com/gfm/#example-197
@@ -18,12 +13,12 @@ test_that("md_blank creates lines that are ignored (ex. 197)", {
   )
   md_convert(lines) %>%
     read_html() %>%
-    html_node("p") %>%
+    html_element("p") %>%
     html_text() %>%
     expect_equal("aaa")
   md_convert(lines) %>%
     read_html() %>%
-    html_node("h1") %>%
+    html_element("h1") %>%
     html_text() %>%
     expect_equal("aaa")
 })

--- a/tests/testthat/test-5.1-block-quotes.R
+++ b/tests/testthat/test-5.1-block-quotes.R
@@ -25,7 +25,7 @@ test_that("md_quote can create an empty block quote (ex. 217)", {
   node <- md_quote("") %>%
     md_convert() %>%
     read_html() %>%
-    html_nodes("blockquote") %>%
+    html_elements("blockquote") %>%
     html_text(trim = TRUE)
   expect_nchar(node, 0)
 })
@@ -50,7 +50,7 @@ test_that("md_quotes with blank lines create paragraphs (ex. 222)", {
     md_convert() %>%
     read_html() %>%
     html_node("blockquote") %>%
-    html_nodes("p") %>%
+    html_elements("p") %>%
     html_text(trim = TRUE)
   expect_equal(node, text[which(text != "")])
 })
@@ -61,6 +61,6 @@ test_that("md_quote can create nested block qutoes (ex. 228)", {
   nodes <- lines %>%
     md_convert() %>%
     read_html() %>%
-    html_nodes("blockquote")
+    html_elements("blockquote")
   expect_length(nodes, 3)
 })

--- a/tests/testthat/test-5.1-block-quotes.R
+++ b/tests/testthat/test-5.1-block-quotes.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_quote creates a <blockquote> tag with other blocks (ex. 206)", {
   # https://github.github.com/gfm/#example-206
@@ -10,12 +5,12 @@ test_that("md_quote creates a <blockquote> tag with other blocks (ex. 206)", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("blockquote") %>%
+    html_element("blockquote") %>%
     expect_full()
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("h1") %>%
+    html_element("h1") %>%
     html_text() %>%
     expect_equal("Foo")
 })
@@ -37,7 +32,7 @@ test_that("md_quotes with soft lines create a single quote (ex. 221)", {
     md_quote() %>%
     md_convert() %>%
     read_html() %>%
-    html_node("blockquote") %>%
+    html_element("blockquote") %>%
     html_text(trim = TRUE) %>%
     expect_equal(expected = str_c(text, collapse = "\n"))
 })
@@ -49,7 +44,7 @@ test_that("md_quotes with blank lines create paragraphs (ex. 222)", {
     md_quote() %>%
     md_convert() %>%
     read_html() %>%
-    html_node("blockquote") %>%
+    html_element("blockquote") %>%
     html_elements("p") %>%
     html_text(trim = TRUE)
   expect_equal(node, text[which(text != "")])

--- a/tests/testthat/test-5.3-task-list.R
+++ b/tests/testthat/test-5.3-task-list.R
@@ -12,7 +12,7 @@ test_that("md_task creates an <ul> list with checks (ex. 279)", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text()
   list %>%
     str_remove("\\[.*\\]\\s") %>%
@@ -29,7 +29,7 @@ test_that("md_task creates an <ul> list without checks", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     str_remove("\\[.*\\]\\s") %>%
     expect_equal(text)

--- a/tests/testthat/test-5.3-task-list.R
+++ b/tests/testthat/test-5.3-task-list.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_task creates an <ul> list with checks (ex. 279)", {
   # https://github.github.com/gfm/#example-279
@@ -11,7 +6,7 @@ test_that("md_task creates an <ul> list with checks (ex. 279)", {
   list <- lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ul") %>%
+    html_element("ul") %>%
     html_elements("li") %>%
     html_text()
   list %>%
@@ -28,7 +23,7 @@ test_that("md_task creates an <ul> list without checks", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ul") %>%
+    html_element("ul") %>%
     html_elements("li") %>%
     html_text() %>%
     str_remove("\\[.*\\]\\s") %>%

--- a/tests/testthat/test-5.4-lists.R
+++ b/tests/testthat/test-5.4-lists.R
@@ -12,7 +12,7 @@ test_that("md_bullet creates an <ul> tag with vector text (ex. 281)", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })
@@ -25,7 +25,7 @@ test_that("md_order creates an <ol> tag with vector text (ex. 282)", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })
@@ -37,7 +37,7 @@ test_that("md_order works without sequence", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })
@@ -49,7 +49,7 @@ test_that("md_order can pad when markers differ in length", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
 })

--- a/tests/testthat/test-5.4-lists.R
+++ b/tests/testthat/test-5.4-lists.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_bullet creates an <ul> tag with vector text (ex. 281)", {
   # https://github.github.com/gfm/#example-281
@@ -11,7 +6,7 @@ test_that("md_bullet creates an <ul> tag with vector text (ex. 281)", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ul") %>%
+    html_element("ul") %>%
     html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
@@ -24,7 +19,7 @@ test_that("md_order creates an <ol> tag with vector text (ex. 282)", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ol") %>%
+    html_element("ol") %>%
     html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
@@ -36,7 +31,7 @@ test_that("md_order works without sequence", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ol") %>%
+    html_element("ol") %>%
     html_elements("li") %>%
     html_text() %>%
     expect_equal(text)
@@ -48,7 +43,7 @@ test_that("md_order can pad when markers differ in length", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ol") %>%
+    html_element("ol") %>%
     html_elements("li") %>%
     html_text() %>%
     expect_equal(text)

--- a/tests/testthat/test-6.1-backslash-escape.R
+++ b/tests/testthat/test-6.1-backslash-escape.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_escape prepends ASCII punctuation with a backslash (ex. 308)", {
   # https://github.github.com/gfm/#example-308
@@ -19,6 +14,6 @@ test_that("md_escape prevents italic emphasis (ex. 311)", {
     md_escape() %>%
     md_convert() %>%
     read_html() %>%
-    html_node("em")
+    html_element("em")
   expect_true(is.na(node))
 })

--- a/tests/testthat/test-6.10-raw-html.R
+++ b/tests/testthat/test-6.10-raw-html.R
@@ -1,14 +1,10 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_convert can optionally disallow certain HTML", {
   "foo" %>%
     md_bold() %>%
     md_convert(disallow = FALSE) %>%
     read_html() %>%
-    html_node("strong") %>%
+    html_element("strong") %>%
     html_text() %>%
     expect_equal("foo")
 })

--- a/tests/testthat/test-6.11-disallow-raw-html.R
+++ b/tests/testthat/test-6.11-disallow-raw-html.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_disallow removes certain tags (ex. 653)", {
   # https://github.github.com/gfm/#example-653

--- a/tests/testthat/test-6.12-hard-line-breaks.R
+++ b/tests/testthat/test-6.12-hard-line-breaks.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_hardline creates a <br /> tag (ex. 655)", {
   # https://github.github.com/gfm/#example-655
@@ -10,6 +6,6 @@ test_that("md_hardline creates a <br /> tag (ex. 655)", {
     md_hardline() %>%
     md_convert() %>%
     read_html() %>%
-    html_node("br") %>%
+    html_element("br") %>%
     expect_full()
 })

--- a/tests/testthat/test-6.13-soft-line-breaks.R
+++ b/tests/testthat/test-6.13-soft-line-breaks.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_softline creates a single <p> tag (ex. 669)", {
   # https://github.github.com/gfm/#example-669
@@ -10,7 +6,7 @@ test_that("md_softline creates a single <p> tag (ex. 669)", {
   md_softline(x) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
+    html_element("p") %>%
     html_text() %>%
     expect_equal(y)
 })

--- a/tests/testthat/test-6.14-textual-content.R
+++ b/tests/testthat/test-6.14-textual-content.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_text creates a vector of glue class", {
    expect_s3_class(md_text("foo"), "glue")
@@ -13,7 +9,7 @@ test_that("md_text creates plain textual content (ex. 671)", {
   md_text(text) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
+    html_element("p") %>%
     html_text() %>%
     expect_equal(text)
 })

--- a/tests/testthat/test-6.3-code-spans.R
+++ b/tests/testthat/test-6.3-code-spans.R
@@ -1,15 +1,10 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_code creates a <code> tag (ex. 338)", {
   # https://github.github.com/gfm/#example-338
   md_code("foo") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("code") %>%
+    html_element("code") %>%
     html_text() %>%
     expect_equal("foo")
 })
@@ -19,7 +14,7 @@ test_that("md_code double backticks if code contains backtick (ex. 339)", {
   md_code("foo ` bar") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("code") %>%
+    html_element("code") %>%
     html_text() %>%
     expect_equal("foo ` bar")
 })

--- a/tests/testthat/test-6.4-emphasis.R
+++ b/tests/testthat/test-6.4-emphasis.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_italic creates a <em> tag (ex. 360)", {
   # https://github.github.com/gfm/#example-360
@@ -9,7 +5,7 @@ test_that("md_italic creates a <em> tag (ex. 360)", {
   md_italic(text) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("em") %>%
+    html_element("em") %>%
     html_text() %>%
     expect_equal(text)
 })
@@ -20,7 +16,7 @@ test_that("md_bold creates a <strong> tag (ex. 387)", {
   md_bold(text) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("strong") %>%
+    html_element("strong") %>%
     html_text() %>%
     expect_equal(text)
 })

--- a/tests/testthat/test-6.5-strikethrough.R
+++ b/tests/testthat/test-6.5-strikethrough.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_strike creates a <del> tag (ex. 491)", {
   # https://github.github.com/gfm/#example-491
@@ -9,13 +5,13 @@ test_that("md_strike creates a <del> tag (ex. 491)", {
   text %>%
     md_convert() %>%
     read_html() %>%
-    html_node("del") %>%
+    html_element("del") %>%
     html_text() %>%
     expect_equal("Hi")
   text %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
+    html_element("p") %>%
     html_text() %>%
     expect_equal(gsub("~", "", text))
 })

--- a/tests/testthat/test-6.6-links.R
+++ b/tests/testthat/test-6.6-links.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_link can create a valid <href> tag (ex. 493)", {
   # https://github.github.com/gfm/#example-493
@@ -10,19 +5,19 @@ test_that("md_link can create a valid <href> tag (ex. 493)", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_text(trim = TRUE) %>%
     expect_equal("link")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal("/url")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_attr("title") %>%
     expect_equal("title")
 })
@@ -33,19 +28,19 @@ test_that("md_link can create <href> tags with a named vector", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_text(trim = TRUE) %>%
     expect_equal("link")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal("/url")
   # lines %>%
   #   md_convert() %>%
   #   read_html() %>%
-  #   html_node("a") %>%
+  #   html_element("a") %>%
   #   html_attr("title") %>%
   #   expect_equal("title")
 })
@@ -55,13 +50,13 @@ test_that("md_link can create <href> tags with a named vector", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_text(trim = TRUE) %>%
     expect_equal("link")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal("/url")
 })
@@ -72,19 +67,19 @@ test_that("md_link can create a valid <href> without title (ex. 494)", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_text(trim = TRUE) %>%
     expect_equal("link")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal("/url")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_attr("title") %>%
     expect_missing()
 })
@@ -95,22 +90,22 @@ test_that("md_reference can create an <href> tag (ex. 535)", {
   md_paragraph("[foo][bar]", lines) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
-    html_node("a") %>%
+    html_element("p") %>%
+    html_element("a") %>%
     html_text(trim = TRUE) %>%
     expect_equal("foo")
   md_paragraph("[foo][bar]", lines) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
-    html_node("a") %>%
+    html_element("p") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal("/url")
   md_paragraph("[foo][bar]", lines) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
-    html_node("a") %>%
+    html_element("p") %>%
+    html_element("a") %>%
     html_attr("title") %>%
     expect_equal("title")
 })
@@ -123,8 +118,8 @@ test_that("md_label and md_reference can create an <href> tag (ex. 535)", {
   ) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
-    html_node("a") %>%
+    html_element("p") %>%
+    html_element("a") %>%
     html_text(trim = TRUE) %>%
     expect_equal("foo")
   md_paragraph(
@@ -133,8 +128,8 @@ test_that("md_label and md_reference can create an <href> tag (ex. 535)", {
   ) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
-    html_node("a") %>%
+    html_element("p") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal("/url")
 })
@@ -147,8 +142,8 @@ test_that("md_label and md_reference can create an <href> tag (ex. 535)", {
   ) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
-    html_node("a") %>%
+    html_element("p") %>%
+    html_element("a") %>%
     html_text(trim = TRUE) %>%
     expect_equal("foo")
   md_paragraph(
@@ -157,8 +152,8 @@ test_that("md_label and md_reference can create an <href> tag (ex. 535)", {
   ) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("p") %>%
-    html_node("a") %>%
+    html_element("p") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal("/url")
 })

--- a/tests/testthat/test-6.7-images.R
+++ b/tests/testthat/test-6.7-images.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_image creates a <img> tag (ex. 580)", {
   # https://github.github.com/gfm/#example-580
@@ -10,19 +5,19 @@ test_that("md_image creates a <img> tag (ex. 580)", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("img") %>%
+    html_element("img") %>%
     html_attr("src") %>%
     expect_equal("/url")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("img") %>%
+    html_element("img") %>%
     html_attr("alt") %>%
     expect_equal("foo")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("img") %>%
+    html_element("img") %>%
     html_attr("title") %>%
     expect_equal("title")
 })
@@ -33,13 +28,13 @@ test_that("md_image creates a <img> tag without title (ex. 580)", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("img") %>%
+    html_element("img") %>%
     html_attr("src") %>%
     expect_equal("/url")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("img") %>%
+    html_element("img") %>%
     html_attr("alt") %>%
     expect_equal("foo")
 })
@@ -49,13 +44,13 @@ test_that("md_image creates a <img> tag from named vector", {
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("img") %>%
+    html_element("img") %>%
     html_attr("src") %>%
     expect_equal("/url")
   lines %>%
     md_convert() %>%
     read_html() %>%
-    html_node("img") %>%
+    html_element("img") %>%
     html_attr("alt") %>%
     expect_equal("foo")
 })

--- a/tests/testthat/test-6.8-autolinks.R
+++ b/tests/testthat/test-6.8-autolinks.R
@@ -1,7 +1,3 @@
-library(testthat)
-library(gluedown)
-library(rvest)
-library(glue)
 
 test_that("md_autolink creates a <a> tag (ex. 602)", {
   # https://github.github.com/gfm/#example-602
@@ -9,7 +5,7 @@ test_that("md_autolink creates a <a> tag (ex. 602)", {
   md_autolink(url) %>%
     md_convert() %>%
     read_html() %>%
-    html_node("a") %>%
+    html_element("a") %>%
     html_attr("href") %>%
     expect_equal(url)
 })

--- a/tests/testthat/test-generic-functions.R
+++ b/tests/testthat/test-generic-functions.R
@@ -63,12 +63,8 @@ test_that("md_chunk errors in the same was as underlying function", {
 })
 
 test_that("md_convert fails without markdown", {
-  skip_if_not_installed("mockr")
-  mockr::with_mock(
-    .env = as.environment("package:gluedown"),
-    `has_markdown` = function() FALSE,
-    expect_error(md_convert("**bold**"))
-  )
+  local_mocked_bindings(has_markdown = function() FALSE)
+  expect_error(md_convert("**bold**"))
 })
 
 test_that("md_convert works without dissalowing HTML", {

--- a/tests/testthat/test-generic-functions.R
+++ b/tests/testthat/test-generic-functions.R
@@ -1,8 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(glue)
 
 test_that("md_list can create all list types", {
   x <- c("foo", "bar", "baz")
@@ -10,7 +5,7 @@ test_that("md_list can create all list types", {
     md_list(type = "bullet") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ul") %>%
+    html_element("ul") %>%
     html_elements("li") %>%
     html_text() %>%
     expect_equal(x)
@@ -18,7 +13,7 @@ test_that("md_list can create all list types", {
     md_list(type = "task") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ul") %>%
+    html_element("ul") %>%
     html_elements("li") %>%
     html_text() %>%
     str_remove("\\[(.*)\\]\\s") %>%
@@ -27,7 +22,7 @@ test_that("md_list can create all list types", {
     md_list(type = "order") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("ol") %>%
+    html_element("ol") %>%
     html_elements("li") %>%
     html_text() %>%
     expect_equal(x)
@@ -40,7 +35,7 @@ test_that("md_chunk can create all list types", {
     md_chunk(type = "indent") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("pre") %>%
+    html_element("pre") %>%
     html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
@@ -48,7 +43,7 @@ test_that("md_chunk can create all list types", {
     md_chunk(type = "tick") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("pre") %>%
+    html_element("pre") %>%
     html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
@@ -56,7 +51,7 @@ test_that("md_chunk can create all list types", {
     md_chunk(type = "tilde") %>%
     md_convert() %>%
     read_html() %>%
-    html_node("pre") %>%
+    html_element("pre") %>%
     html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
@@ -80,7 +75,7 @@ test_that("md_convert works without dissalowing HTML", {
   html <- md_convert("<title>Title</title>", disallow = FALSE)
   html %>%
     read_html() %>%
-    html_node("title") %>%
+    html_element("title") %>%
     html_text() %>%
     expect_equal("Title")
 })

--- a/tests/testthat/test-generic-functions.R
+++ b/tests/testthat/test-generic-functions.R
@@ -11,7 +11,7 @@ test_that("md_list can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(x)
   x %>%
@@ -19,7 +19,7 @@ test_that("md_list can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("ul") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     str_remove("\\[(.*)\\]\\s") %>%
     expect_equal(x)
@@ -28,7 +28,7 @@ test_that("md_list can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("ol") %>%
-    html_nodes("li") %>%
+    html_elements("li") %>%
     html_text() %>%
     expect_equal(x)
 })
@@ -41,7 +41,7 @@ test_that("md_chunk can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("pre") %>%
-    html_nodes("code") %>%
+    html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
   x %>%
@@ -49,7 +49,7 @@ test_that("md_chunk can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("pre") %>%
-    html_nodes("code") %>%
+    html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
   x %>%
@@ -57,7 +57,7 @@ test_that("md_chunk can create all list types", {
     md_convert() %>%
     read_html() %>%
     html_node("pre") %>%
-    html_nodes("code") %>%
+    html_elements("code") %>%
     html_text(trim = TRUE) %>%
     expect_equal(y)
 })

--- a/tests/testthat/test-github-issue.R
+++ b/tests/testthat/test-github-issue.R
@@ -1,10 +1,3 @@
-library(testthat)
-library(gluedown)
-library(stringr)
-library(rvest)
-library(knitr)
-library(glue)
-
 test_that("md_issue creates GitHub auto-link URL", {
   issue <- md_issue("k5cents/gluedown", 1)
   convert <- str_c("https://github.com/", str_replace(issue, "#", "/issues/"))

--- a/vignettes/github-spec.Rmd
+++ b/vignettes/github-spec.Rmd
@@ -577,14 +577,7 @@ md_image("https://www.r-project.org/Rlogo.png", alt = "R logo")
 ```
 
 ```{r echo=FALSE, results='asis'}
-tmp <- tempfile(fileext = ".png")
-  try <- tryCatch(
-    expr = download.file("https://www.r-project.org/Rlogo.png", tmp),
-    error = function(e) return(NULL)
-  )
-  if (!is.null(try)) {
-    md_image(tmp, alt = "R logo")
-  }
+md_image("https://www.r-project.org/Rlogo.png", alt = "R logo")
 ```
 
 ### 6.11 Disallowed Raw HTML (extension)


### PR DESCRIPTION
Closes #38. Also completes #36 (fully migrates deprecated rvest selectors).

## Changes

**`DESCRIPTION`** — Bump `testthat (>= 2.1.0)` to `>= 3.0.0`; add `Config/testthat/edition: 3`.

**`tests/testthat/helper-packages.R`** (new) — Centralises `library(rvest)`, `library(glue)`, and `library(stringr)` in one place. testthat loads `helper-*.R` files before all tests, so each test file no longer needs its own library calls.

**All 26 test files** — Remove top-level `library(testthat)`, `library(gluedown)`, `library(rvest)`, `library(glue)`, `library(stringr)`, and `library(knitr)` (196 lines deleted across the suite). Also drop unused `library(knitr)` from `test-github-issue.R`.

**`html_node()` → `html_element()` (singular)** — The previous `chore/cleanup` PR replaced the plural `html_nodes()`. This PR catches the singular `html_node()`, also deprecated since rvest 1.0.0, across all affected test files.

**`test-4.4-indented-code.R`** — Two `expect_that()` calls (removed in edition 3) converted to `test_that()`. This recovers 6 tests that were silently not running.

## Tests

[ FAIL 0 | WARN 0 | SKIP 9 | PASS 134 ] — up from 128 passing before (the 6 recovered tests).