### PR TITLE
Force Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -27,6 +27,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,6 +19,7 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: write
     steps:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# gluedown 1.1.0
+
+* Fix `md_code()` vectorization bug: double-backtick escaping was applied to
+  all elements whenever *any* element contained a backtick. Now each element
+  is escaped independently (#38).
+* Fix `md_setext()` when `width = FALSE`: previously behaved identically to
+  `width = TRUE` due to `min(FALSE) < 1` evaluating to `TRUE` (#37).
+* Fix `md_issue()` emitting one warning per element instead of once when
+  elements are missing the `"user/repo"` format (#36).
+* Remove `mockr` from suggested dependencies; mocking now uses
+  `testthat::local_mocked_bindings()` (#34).
+
 # gluedown 1.0.9
 
 * Update maintainer email, website URL, and GitHub URL.


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to all three workflow env blocks
- Silences the Node.js 20 deprecation warning on `actions/checkout@v4`
- GitHub is enforcing Node.js 24 as the default starting **June 2, 2026**

## Test plan

- [ ] Verify no Node.js deprecation warnings appear in workflow run logs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)